### PR TITLE
Enable plaintext SMTP access

### DIFF
--- a/lib/Horde/Smtp.php
+++ b/lib/Horde/Smtp.php
@@ -167,7 +167,7 @@ class Horde_Smtp implements Serializable
             'port' => 587,
             'secure' => true,
             'timeout' => 30
-        ), array_filter($params));
+        ), $params);
 
         foreach ($params as $key => $val) {
             $this->setParam($key, $val);


### PR DESCRIPTION
Smtp.php gets 'secure' param with false in case plaintext connection as the comment says.
`array_filter` without callback function removes false value.
```
$ php -r 'var_dump(array_filter(["a", false, "b"]));'
array(2) {
  [0]=>
  string(1) "a"
  [2]=>
  string(1) "b"
}
```

So, I think at least here should accept false value to enable plaintext connection.